### PR TITLE
Fix Lagom.scala list of templtates. Adds warning in code

### DIFF
--- a/scripts/templates-lagom.sh
+++ b/scripts/templates-lagom.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+##  Keep the templates list in sync with ./src/main/scala/model/Lagom.scala !
+
 declare -a lagom_templates=( 
    "online-auction-scala"
    "online-auction-java"

--- a/scripts/templates-play.sh
+++ b/scripts/templates-play.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+##  Keep the templates list in sync with ./src/main/scala/model/Play.scala !
+
 declare -a play_templates=(
   "play-java-starter-example"
   "play-scala-starter-example"

--- a/src/main/scala/templatecontrol/model/Lagom.scala
+++ b/src/main/scala/templatecontrol/model/Lagom.scala
@@ -6,19 +6,32 @@ object Lagom {
 
   private def mkTemplate(name: String) = Template(name, "lagom")
 
+
+  // Keep the templates list in sync with ./scripts/templates-lagom.sh !
+
+  // all templates
   private def templates = Seq(
     "lagom-java.g8",
     "lagom-scala.g8",
     "online-auction-java",
     "online-auction-scala",
-    "lagom-java-grpc-example",
-    "lagom-scala-grpc-example",
     "lagom-java-maven-chirper-example",
     "lagom-java-sbt-chirper-example",
+    "lagom-java-grpc-example",
+    "lagom-scala-grpc-example",
+    "lagom-scala-openshift-smoketests",
+    "lagom-java-openshift-smoketests",
+    "shopping-cart-scala",
+    "shopping-cart-java"
   )
 
+  // templates added for Lagom 1.5.x
   private def templates15 = Seq(
     "lagom-java-grpc-example",
     "lagom-scala-grpc-example",
+    "lagom-scala-openshift-smoketests",
+    "lagom-java-openshift-smoketests",
+    "shopping-cart-scala",
+    "shopping-cart-java"
   )
 }

--- a/src/main/scala/templatecontrol/model/Play.scala
+++ b/src/main/scala/templatecontrol/model/Play.scala
@@ -1,5 +1,7 @@
 package templatecontrol.model
 
+// Keep the templates list in sync with ./scripts/templates-play.sh !
+
 object Play {
   def play26 = Project("Play", "2.6.x", templates.diff(templates27).map(mkTemplate))
   def play27 = Project("Play", "2.7.x", templates.map(mkTemplate))


### PR DESCRIPTION
There are two lists of repos in the code: `scripts` and `src/main/.../model/`. The lists must stay in sync.