### PR TITLE
Support `--dry-run` as an argument

### DIFF
--- a/src/main/scala/templatecontrol/TemplateControl.scala
+++ b/src/main/scala/templatecontrol/TemplateControl.scala
@@ -148,7 +148,7 @@ object TemplateControl {
     val config =
       TemplateControlConfig
         .fromTypesafeConfig(ConfigFactory.load())
-        .copy(noPush = args.contains("--no-push"))
+        .copy(noPush = args.contains("--no-push") || args.contains("--dry-run"))
 
     logger.info("running dry-run: " + config.noPush)
 


### PR DESCRIPTION
It is already posible to execute a dry run but the current argument is `--no-push`. This PR adds an alias so `--dry-run` and `--no-push` have the exact same effect.