### PR TITLE
Update to latest versions of AdoptOpenJDK 8 & 11

### DIFF
--- a/templates/.travis.yml
+++ b/templates/.travis.yml
@@ -4,16 +4,16 @@ script: $SCRIPT
 
 env:
   matrix:
-    - SCRIPT=scripts/test-sbt    TRAVIS_JDK=adopt@1.8.202-08
-    - SCRIPT=scripts/test-sbt    TRAVIS_JDK=adopt@1.11.0-2
-    - SCRIPT=scripts/test-gradle TRAVIS_JDK=adopt@1.8.202-08
-    - SCRIPT=scripts/test-gradle TRAVIS_JDK=adopt@1.11.0-2
+    - SCRIPT=scripts/test-sbt    TRAVIS_JDK=adopt@1.8.212-03
+    - SCRIPT=scripts/test-sbt    TRAVIS_JDK=adopt@1.11.0-3
+    - SCRIPT=scripts/test-gradle TRAVIS_JDK=adopt@1.8.212-03
+    - SCRIPT=scripts/test-gradle TRAVIS_JDK=adopt@1.11.0-3
 
 matrix:
   fast_finish: true
   allow_failures:
-    - env: SCRIPT=scripts/test-gradle TRAVIS_JDK=adopt@1.8.202-08 # current gradle doesn't support play 2.7
-    - env: SCRIPT=scripts/test-gradle TRAVIS_JDK=adopt@1.11.0-2   # current gradle doesn't support play 2.7
+    - env: SCRIPT=scripts/test-gradle TRAVIS_JDK=adopt@1.8.212-03 # current gradle doesn't support play 2.7
+    - env: SCRIPT=scripts/test-gradle TRAVIS_JDK=adopt@1.11.0-3   # current gradle doesn't support play 2.7
 
 before_install: curl -Ls https://git.io/jabba | bash && . ~/.jabba/jabba.sh
 install: jabba install "$TRAVIS_JDK" && jabba use "$_" && java -Xmx32m -version


### PR DESCRIPTION
Using the latest versions listed by `jabba ls-remote`.